### PR TITLE
Enable nested code-samples to be highlighted

### DIFF
--- a/reveal-code-focus.js
+++ b/reveal-code-focus.js
@@ -148,7 +148,12 @@
       codeBlock = 1;
     }
 
-    var code = currentSlide.querySelectorAll('pre:nth-of-type(' + codeBlock + ') code .line');
+	var pres = currentSlide.querySelectorAll('pre')[codeBlock - 1];
+	if (!pres || pres.length === 0) {
+		return;
+	}
+
+	var code = pres.querySelectorAll('code .line');
     if (!code) {
       return;
     }


### PR DESCRIPTION
The former code chose every n-th "pre"-element, which was a direct child of the slide's section-element. It has been modified to query all "pre"-elements in the slide and choose the n-th element. This allows code-fragements to be displayed beside each other using e.g. flexbox.

Because querySelectorAll() uses pre-order traversal, the numbering would match the html-definition:

```
<div>
	<pre><code></code></pre> <!-- data-code-block = 1 -->
	<div>
		<pre><code></code></pre> <!-- data-code-block = 2 -->
	</div>
	<div>
		<pre><code></code></pre> <!-- data-code-block = 3 -->
	</div>
</div>
```